### PR TITLE
Update ubuntu versions

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   book-rss:
     name: "Generate RSS"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
I updated ubuntu version used in .github/workflows/update.yml.
Ubuntu 18.04 image is being deprecated.
https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/