### PR TITLE
feat: support Github Actions

### DIFF
--- a/src/RSS_FEEDS.ts
+++ b/src/RSS_FEEDS.ts
@@ -46,5 +46,9 @@ export const RSS_FEEDS: RSS_FEED[] = [
     {
         title: "Security Advisory for Erlang/Elixir packages hosted at hex.pm",
         ...createBase("ERLANG")
-    }
+    },
+    {
+        title: "Security Advisory for Github Actions",
+        ...createBase("ACTIONS")
+    },
 ];


### PR DESCRIPTION
Github Advisory Database now supports Github Actions.
New feeds will be added accordingly.
https://github.blog/changelog/2022-08-09-advisory-database-supports-github-actions-advisories/

（Thank you for all your help!）