### PR TITLE
Fix categories consistency in rss

### DIFF
--- a/src/generate-rss.ts
+++ b/src/generate-rss.ts
@@ -141,8 +141,8 @@ export const generateRSS = (items: Item[], options: GenerateRSSOptions) => {
             link: item.url,
             category: [
                 {
-                    term: "severity",
-                    name: item.severity
+                    term: item.severity,
+                    name: "severity"
                 }
             ],
             author: [


### PR DESCRIPTION
My previous inversion was inconsistent - first try was correct as the severity should be displayed as a TERM like showed above in the feed declaration. I opened an issue on the "feed" project to investigate why it's showing the "label" field in the json result instead of the "term" : https://github.com/jpmonette/feed/issues/178 